### PR TITLE
move test deps to test profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,10 +34,18 @@
 {sub_dirs, [
            ]}.
 
-{deps,
-  [
-   {meck,             ".*", {git, "git://github.com/eproxus/meck.git",            {tag, "0.8.2"}}},
-   {reloader,         ".*", {git, "git://github.com/sile/reloader.git",           {branch, "master"}}},
-   {edown,            ".*", {git, "git://github.com/dwango/edown.git",            {branch, "master"}}},
-   {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {branch, "master"}}}
-  ]}.
+{profiles, [{test,
+            [{deps,
+              [
+              {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
+              {edown, ".*", {git, "git://github.com/dwango/edown.git", {branch, "master"}}},
+              {eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters", {branch, "master"}}}
+              ]}
+]},
+            {dev, [{deps,
+                   [{reloader, ".*", {git, "git://github.com/sile/reloader.git", {branch, "master"}}}]
+                   }
+                  ]
+            }
+           ]
+}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,16 +1,1 @@
-[{<<"reloader">>,
-  {git,"git://github.com/sile/reloader.git",
-       {ref,"ab13271c015f73a52ab5d01d989f5ea110c272d8"}},
-  0},
- {<<"meck">>,
-  {git,"git://github.com/eproxus/meck.git",
-       {ref,"dde759050eff19a1a80fd854d7375174b191665d"}},
-  0},
- {<<"eunit_formatters">>,
-  {git,"git://github.com/seancribbs/eunit_formatters",
-       {ref,"2c73eb6e46b0863f19507857b386a48a53aaf141"}},
-  0},
- {<<"edown">>,
-  {git,"git://github.com/dwango/edown.git",
-       {ref,"dd1239c1d8669b247ceac83b1654fa55c675d8f3"}},
-  0}].
+[].


### PR DESCRIPTION
This is so deps that aren't needed for using mustache as a lib aren't fetched/built unless they are needed. `rebar3 eunit` works as before, it runs as the test profile.

I partly went to do this because I'd like to get mustache published to hex.pm, but the main issue now with publishing to hex is there is already a mustache, https://hex.pm/packages/mustache :(

Would you be open to a name change? Just the app name needs to change, not the `mustache.erl` module, that can stay the same. The repo name can even stay the same. Pretty sure just changing the application name to something else, like `mustache_erl`, would be enough.